### PR TITLE
Make it working with Ruby 2.3

### DIFF
--- a/lib/rails/keyserver/engine.rb
+++ b/lib/rails/keyserver/engine.rb
@@ -15,7 +15,7 @@ module Rails
       # URL:
       # https://blog.pivotal.io/labs/labs/leave-your-migrations-in-your-rails-engines
       initializer :append_migrations do |app|
-        unless app.root.to_s.match? root.to_s
+        unless app.root.to_s.match root.to_s
           config.paths["db/migrate"].expanded.each do |expanded_path|
             app.config.paths["db/migrate"] << expanded_path
           end


### PR DESCRIPTION
Method `#match?` is not available in Ruby 2.3.  It is being replaced with slightly slower `#match`.